### PR TITLE
Add Github workflow to scrape IOCs from Sophos repository

### DIFF
--- a/.github/workflows/scrape_sophos_iocs.yml
+++ b/.github/workflows/scrape_sophos_iocs.yml
@@ -1,0 +1,38 @@
+name: Fetch Sophos IoCs
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'  # Runs every 12 hours
+  workflow_dispatch:  # Allows manual trigger
+
+jobs:
+  update-iocs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for pushing commits
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+          pip install iocparser
+
+      - name: Run IoC fetcher
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Token automatically provided by GitHub
+        run: python scripts/fetch_iocs.py  # Assuming script is in scripts directory
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update Sophos IoCs"
+          file_pattern: 'latest_commit.txt sophos_iocs.txt'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # GithubIOC_Collector
-To Collect IoCs from Known Github Repos
+To Collect IoCs from Known Github Repos, including the Sophos github repository

--- a/scrape_sophos_iocs.py
+++ b/scrape_sophos_iocs.py
@@ -1,0 +1,84 @@
+import requests
+import os
+from iocparser import IOCParser
+
+class SophosIOCFetcher:
+    def __init__(self):
+        self.base_url = "https://api.github.com/repos/sophoslabs/IoCs"
+        self.commit_file = "latest_commit.txt"
+        self.output_file = "sophos_iocs.txt"
+        self.github_token = os.getenv('GITHUB_TOKEN')
+        self.headers = {
+            'Authorization': f'Bearer {self.github_token}',
+            'Accept': 'application/vnd.github.v3+json'
+        }
+
+    def _get_latest_commit(self):
+        response = requests.get(
+            f"{self.base_url}/commits",
+            headers=self.headers
+        )
+        response.raise_for_status()
+        return response.json()[0]['sha']
+
+    def _read_saved_commit(self):
+        if not os.path.exists(self.commit_file):
+            return ""
+        with open(self.commit_file, "r") as f:
+            return f.read().strip()
+
+    def _save_commit(self, commit_sha):
+        with open(self.commit_file, "w") as f:
+            f.write(commit_sha)
+
+    def _download_ioc_files(self):
+        response = requests.get(
+            f"{self.base_url}/contents",
+            headers=self.headers
+        )
+        response.raise_for_status()
+        
+        iocs = []
+        for file in response.json():
+            if file['name'].lower().endswith(('.csv', '.txt')):
+                file_response = requests.get(
+                    file['download_url'],
+                    headers=self.headers
+                )
+                file_response.raise_for_status()
+                iocs.append(file_response.text)
+        return iocs
+
+    def _parse_iocs(self, data):
+        iocs = []
+        for item in data:
+            parser = IOCParser(item)
+            iocs.extend(parser.parse())
+        return iocs
+
+    def _save_iocs(self, iocs):
+        with open(self.output_file, 'w') as f:
+            f.write('\n'.join(iocs))
+
+    def fetch_and_save(self):
+        latest_commit = self._get_latest_commit()
+        saved_commit = self._read_saved_commit()
+
+        if latest_commit == saved_commit:
+            return False
+
+        ioc_data = self._download_ioc_files()
+        if not ioc_data:
+            return False
+
+        parsed_iocs = self._parse_iocs(ioc_data)
+        self._save_iocs(parsed_iocs)
+        self._save_commit(latest_commit)
+        return True
+
+def main():
+    fetcher = SophosIOCFetcher()
+    return fetcher.fetch_and_save()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Related to #1

Add functionality to scrape IOCs from the Sophos GitHub repository.


* **.github/workflows/scrape_sophos_iocs.yml**
  - Add a new GitHub workflow file to scrape IOCs from the Sophos repository.
  - Include steps to set up Python, install dependencies, and run the script.

* **scrape_sophos_iocs.py**
  - Add a new Python script to scrape IOCs from the Sophos repository.
  - Use the `requests` library to fetch data from the Sophos repository.
  - Parse the fetched data to extract IOCs and save them to a file.
  - Check for recently published or updated files in the latest commit and recheck for the latest published files whenever the commit hash changes.
  - Read files with extensions .csv or .txt and use IOC parser to parse observables such as domain names, hashes, URLs, and IPs.

